### PR TITLE
Task 7: Add authorization header to import endpoint

### DIFF
--- a/src/app/core/interceptors/secure-call-interceptor.ts
+++ b/src/app/core/interceptors/secure-call-interceptor.ts
@@ -1,0 +1,62 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest,
+} from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { NotificationService } from '../notification.service';
+import { tap } from 'rxjs/operators';
+
+const SECURE_ENDPOINTS = ['products/import'];
+
+@Injectable()
+export class SecureCallInterceptor implements HttpInterceptor {
+  constructor(private readonly notificationService: NotificationService) {}
+
+  intercept(
+    request: HttpRequest<unknown>,
+    next: HttpHandler,
+  ): Observable<HttpEvent<unknown>> {
+    const url = new URL(request.url);
+    const endpoint = url.pathname;
+    console.log(
+      `SecureCallInterceptor: Intercepting request to "${url.pathname}"`,
+    );
+
+    if (
+      SECURE_ENDPOINTS.some((secureEndpoint) =>
+        endpoint.includes(secureEndpoint),
+      )
+    ) {
+      const token = localStorage.getItem('token');
+      if (!token) {
+        this.notificationService.showError(
+          `You must be logged in to access "${url.pathname}". Please log in and try again.`,
+          0,
+        );
+        return throwError(
+          () => new Error(`Unauthorized access to "${url.pathname}"`),
+        );
+      }
+
+      request = request.clone({
+        setHeaders: {
+          Authorization: `Basic ${token}`,
+        },
+      });
+    }
+
+    return next.handle(request).pipe(
+      tap({
+        error: () => {
+          this.notificationService.showError(
+            `Request to "${url.pathname}" failed. Check the console for the details`,
+            0,
+          );
+        },
+      }),
+    );
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,11 +13,17 @@ import {
 } from '@angular/common/http';
 import { provideRouter, withComponentInputBinding } from '@angular/router';
 import { appRoutes } from './app/app-routes';
+import { SecureCallInterceptor } from './app/core/interceptors/secure-call-interceptor';
 
 const interceptors: Provider[] = [
   {
     provide: HTTP_INTERCEPTORS,
     useClass: ErrorPrintInterceptor,
+    multi: true,
+  },
+  {
+    provide: HTTP_INTERCEPTORS,
+    useClass: SecureCallInterceptor,
     multi: true,
   },
 ];


### PR DESCRIPTION
### What's New

- Implemented an Angular HTTP interceptor to automatically attach the `Authorization` header with a `Basic` token for all outgoing HTTP requests.

  - When the token is no in local storage the interceptor will block the request.
  ![Screenshot 2025-05-31 at 11 35 47 AM](https://github.com/user-attachments/assets/551e6bca-6a95-4c6c-a4f6-d9842079ec72)
  - When the token is in local storage then the request will resume.
  ![Screenshot 2025-05-31 at 11 39 44 AM](https://github.com/user-attachments/assets/8574a654-8afb-477f-81fb-a30c8158dbce)
  - Requests that don't require authorization are allowed to proceed without the token.
  ![Screenshot 2025-05-31 at 11 43 35 AM](https://github.com/user-attachments/assets/f3992341-52d3-4ef4-9909-f47e2cb9427c)

- Includes notifications for failed requests
![Screenshot 2025-05-31 at 12 17 30 PM](https://github.com/user-attachments/assets/d6b111d8-6b30-4551-af87-68a70fe70cd9)


